### PR TITLE
Don't override student causal mask

### DIFF
--- a/tests/test_attention_block.py
+++ b/tests/test_attention_block.py
@@ -121,10 +121,7 @@ def test_eager_causal_attention_block(with_mask):
 
         # Copy weights from reference to student model to ensure identical initialization, but don't
         # override student model causal mask.
-        ref_state_dict = ref_model.state_dict()
-        student_causal_mask = student_model.state_dict()['causal_mask']
-        ref_state_dict['causal_mask'] = student_causal_mask
-        student_model.load_state_dict(ref_state_dict)
+        student_model.load_state_dict(ref_model.state_dict() | {"causal_mask": student_model.state_dict()["causal_mask"]})
 
         # Forward pass
         with torch.no_grad():

--- a/tests/test_attention_block.py
+++ b/tests/test_attention_block.py
@@ -119,8 +119,12 @@ def test_eager_causal_attention_block(with_mask):
         student_model = StudentEagerCausal(HIDDEN_DIM, NUM_HEADS, DROPOUT, MAX_SEQ_LEN).to(device)
         ref_model = RefEagerCausal(HIDDEN_DIM, NUM_HEADS, DROPOUT, MAX_SEQ_LEN).to(device)
 
-        # Copy weights from reference to student model to ensure identical initialization
-        student_model.load_state_dict(ref_model.state_dict())
+        # Copy weights from reference to student model to ensure identical initialization, but don't
+        # override student model causal mask.
+        ref_state_dict = ref_model.state_dict()
+        student_causal_mask = student_model.state_dict()['causal_mask']
+        ref_state_dict['causal_mask'] = student_causal_mask
+        student_model.load_state_dict(ref_state_dict)
 
         # Forward pass
         with torch.no_grad():


### PR DESCRIPTION
`tests/test_attention_block.py::test_eager_causal_attention_block` is currently overriding the student model's causal mask, which can give false negatives when the student's causal mask is wrong and false positives when the student's causal masking is implemented differently (e.g. using `False` to indicate masked positions, appropriately coordinated with `forward`).